### PR TITLE
Correct header name to work with Django

### DIFF
--- a/django_helpscout/helpers.py
+++ b/django_helpscout/helpers.py
@@ -20,7 +20,7 @@ def helpscout_request(f):
     """
     @wraps(f)
     def decorated_function(request, *args, **kwargs):
-        helpscout_sig = request.META.get('X-Helpscout-Signature')
+        helpscout_sig = request.META.get('HTTP_X_HELPSCOUT_SIGNATURE')
         secret = b(settings.HELPSCOUT_SECRET)
         request_body = b(request.body)
 


### PR DESCRIPTION
Hi @victorneo! I was using the app but kept getting a 401 response in Helpscout - I tracked it down to Django helpfully capitalising and prepending HTTP_ to all headers.
